### PR TITLE
Make compatible with Mail 7.0

### DIFF
--- a/GMailinator/Info.plist
+++ b/GMailinator/Info.plist
@@ -32,6 +32,8 @@
 		<string>1146A009-E373-4DB6-AB4D-47E59A7E50FD</string>
 		<string>2183B2CD-BEDF-4AA6-AC18-A1BBED2E3354</string>
 		<string>19B53E95-0964-4AAB-88F9-6D2F8B7B6037</string>
+		<string>0941BB9F-231F-452D-A26F-47A43863C991</string>
+		<string>04D6EC0A-52FF-4BBE-9896-C0B5FB851BBA</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Just added the UUID's to tell Mail 7.0 that this plugin is compatible. With this change, the keyboard shortcuts appear to work again.

If there are any specific tests I should do to make sure everything is compatible with Mail 7.0/Mavericks, let me know.
